### PR TITLE
feat: Implement task deletion and scheduled reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,64 @@
-## This is a project for providing todo lists.
-The end.
+# Simple To-Do List Application
+
+This is a command-line application for managing your to-do list. You can add tasks, list them, delete them, and even schedule tasks with reminders.
+
+## Features
+
+### Add a Task
+You can add a new task to your to-do list.
+
+**Syntax:**
+```bash
+python todo.py add "Your task description here"
+```
+
+**Scheduled Tasks:**
+You can also add a task with a specific due date and time.
+
+**Syntax:**
+```bash
+python todo.py add "Your scheduled task description" --time "YYYY-MM-DD HH:MM"
+```
+*   `YYYY-MM-DD HH:MM`: Specify the year, month, day, hour, and minute for the task. For example, "2023-12-25 10:30".
+
+### List Tasks
+View all your current tasks. Tasks with a scheduled time will display the time. If a reminder has been sent for a scheduled task, it will be indicated.
+
+**Syntax:**
+```bash
+python todo.py list
+```
+The output will number each task, which is used for deleting tasks.
+
+### Delete a Task
+Remove a task from your list using its number (obtained from the `list` command).
+
+**Syntax:**
+```bash
+python todo.py delete <task_number>
+```
+*   `<task_number>`: The number of the task you want to delete, as shown in the `list` command output.
+
+### Check Reminders
+Check for any scheduled tasks that are past their due time.
+
+**Syntax:**
+```bash
+python todo.py remind
+```
+*   If a scheduled task is due (its time is in the past), a reminder message will be printed.
+*   Once a reminder has been shown for a task, it will be marked as "reminded" to prevent repeated notifications for the same task. The `list` command will show "(Time: YYYY-MM-DD HH:MM) - Reminder Sent" for such tasks.
+
+## Getting Started
+
+1.  Ensure you have Python installed.
+2.  Save the script as `todo.py`.
+3.  Run the script from your terminal using the commands described above.
+    For example: `python todo.py add "Buy groceries"`
+
+## Task Storage
+Tasks are stored in a file named `tasks.txt` in the same directory as the `todo.py` script.
+If tasks have a scheduled time, they are stored in the format:
+`task_description || YYYY-MM-DD HH:MM`
+If a reminder has been sent, it's stored as:
+`task_description || YYYY-MM-DD HH:MM || reminded`

--- a/test_todo.py
+++ b/test_todo.py
@@ -1,0 +1,189 @@
+import unittest
+import os
+import tempfile
+import shutil
+from datetime import datetime, timedelta
+import io
+import sys
+
+# Assuming todo.py is in the same directory or accessible in PYTHONPATH
+import todo
+
+class TestTodoApp(unittest.TestCase):
+    def setUp(self):
+        # Create a temporary directory to store tasks.txt
+        self.test_dir = tempfile.mkdtemp()
+        self.temp_tasks_file = os.path.join(self.test_dir, "temp_tasks.txt")
+        
+        # Patch todo.TASKS_FILE to use the temporary file
+        self.original_tasks_file = todo.TASKS_FILE
+        todo.TASKS_FILE = self.temp_tasks_file
+        
+        # Ensure the file is created for tests that might try to read/write it immediately
+        with open(self.temp_tasks_file, 'w') as f:
+            pass 
+
+    def tearDown(self):
+        # Restore original TASKS_FILE path
+        todo.TASKS_FILE = self.original_tasks_file
+        # Remove the temporary directory and its contents
+        shutil.rmtree(self.test_dir)
+
+    def _read_tasks_from_temp_file(self):
+        if not os.path.exists(self.temp_tasks_file):
+            return []
+        with open(self.temp_tasks_file, 'r') as f:
+            return [line.strip() for line in f.readlines()]
+
+    def _capture_stdout(self, func, *args, **kwargs):
+        captured_output = io.StringIO()
+        old_stdout = sys.stdout
+        sys.stdout = captured_output
+        try:
+            func(*args, **kwargs)
+        finally:
+            sys.stdout = old_stdout
+        return captured_output.getvalue()
+
+    # --- Test Cases for Task Deletion ---
+    def test_delete_task_valid(self):
+        todo.add_task("Task 1")
+        todo.add_task("Task 2")
+        todo.add_task("Task 3")
+        
+        todo.delete_task(2) # Delete "Task 2"
+        
+        tasks = self._read_tasks_from_temp_file()
+        self.assertEqual(len(tasks), 2)
+        self.assertIn("Task 1", tasks)
+        self.assertNotIn("Task 2", tasks)
+        self.assertIn("Task 3", tasks)
+
+    def test_delete_task_invalid_number_too_high(self):
+        todo.add_task("Task 1")
+        todo.add_task("Task 2")
+        
+        # Capture output to check for error message (optional, but good for CLI apps)
+        output = self._capture_stdout(todo.delete_task, 3) 
+        
+        tasks = self._read_tasks_from_temp_file()
+        self.assertEqual(len(tasks), 2) # No task should be deleted
+        self.assertIn("Invalid task number", output)
+
+    def test_delete_task_invalid_number_zero(self):
+        todo.add_task("Task 1")
+        output = self._capture_stdout(todo.delete_task, 0)
+        tasks = self._read_tasks_from_temp_file()
+        self.assertEqual(len(tasks), 1)
+        self.assertIn("Invalid task number", output)
+
+    def test_delete_task_non_numeric_input(self):
+        todo.add_task("Task A")
+        output = self._capture_stdout(todo.delete_task, "abc")
+        tasks = self._read_tasks_from_temp_file()
+        self.assertEqual(len(tasks), 1) # No task should be deleted
+        self.assertIn("Please enter a valid number", output)
+
+    def test_delete_from_empty_list(self):
+        # Ensure tasks file is empty (setUp does this)
+        self.assertEqual(len(self._read_tasks_from_temp_file()), 0)
+        
+        output = self._capture_stdout(todo.delete_task, 1)
+        
+        tasks = self._read_tasks_from_temp_file()
+        self.assertEqual(len(tasks), 0) # Still empty
+        self.assertIn("No tasks found", output) # Or similar message from your delete_task
+
+    # --- Test Cases for Scheduled Tasks & Reminders ---
+    def test_add_task_with_time(self):
+        todo.add_task("Scheduled Task 1", "2023-12-25 10:30")
+        tasks = self._read_tasks_from_temp_file()
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0], "Scheduled Task 1 || 2023-12-25 10:30")
+
+    def test_add_task_without_time(self):
+        todo.add_task("Simple Task")
+        tasks = self._read_tasks_from_temp_file()
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0], "Simple Task")
+
+    def test_list_tasks_display(self):
+        todo.add_task("Task A (no time)")
+        todo.add_task("Task B (future)", "2099-01-01 12:00")
+        # Add a task that is past and reminded
+        past_time = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d %H:%M")
+        with open(self.temp_tasks_file, 'a') as f:
+            f.write(f"Task C (past, reminded) || {past_time} || reminded\n")
+
+        output = self._capture_stdout(todo.list_tasks)
+        
+        self.assertIn("1. Task A (no time)", output)
+        self.assertIn(f"2. Task B (future) (Time: 2099-01-01 12:00)", output)
+        self.assertIn(f"3. Task C (past, reminded) (Time: {past_time}) - Reminder Sent", output)
+
+    def test_check_reminders_due_task(self):
+        due_time_str = (datetime.now() - timedelta(hours=1)).strftime("%Y-%m-%d %H:%M")
+        todo.add_task("Due Task", due_time_str)
+        
+        output = self._capture_stdout(todo.check_reminders)
+        
+        self.assertIn(f"REMINDER: 'Due Task' was due on {due_time_str}", output)
+        tasks = self._read_tasks_from_temp_file()
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0], f"Due Task || {due_time_str} || reminded")
+
+    def test_check_reminders_future_task(self):
+        future_time_str = (datetime.now() + timedelta(hours=1)).strftime("%Y-%m-%d %H:%M")
+        todo.add_task("Future Task", future_time_str)
+        
+        output = self._capture_stdout(todo.check_reminders)
+        
+        self.assertNotIn("REMINDER:", output)
+        tasks = self._read_tasks_from_temp_file()
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0], f"Future Task || {future_time_str}") # Should not be marked reminded
+
+    def test_check_reminders_already_reminded(self):
+        past_time_str = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d %H:%M")
+        task_line = f"Old Reminded Task || {past_time_str} || reminded"
+        with open(self.temp_tasks_file, 'w') as f:
+            f.write(task_line + '\n')
+            
+        output = self._capture_stdout(todo.check_reminders)
+        
+        self.assertNotIn("REMINDER:", output) # Should not print a new reminder
+        tasks = self._read_tasks_from_temp_file()
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0], task_line) # State should be unchanged
+
+    def test_check_reminders_mixed_tasks(self):
+        past_due_str = (datetime.now() - timedelta(minutes=30)).strftime("%Y-%m-%d %H:%M")
+        future_str = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d %H:%M")
+        already_reminded_past_str = (datetime.now() - timedelta(days=2)).strftime("%Y-%m-%d %H:%M")
+
+        todo.add_task("Task 1 (Past Due)", past_due_str)
+        todo.add_task("Task 2 (Future)", future_str)
+        with open(self.temp_tasks_file, 'a') as f:
+            f.write(f"Task 3 (Already Reminded) || {already_reminded_past_str} || reminded\n")
+        todo.add_task("Task 4 (No Time)")
+        
+        output = self._capture_stdout(todo.check_reminders)
+        
+        self.assertIn(f"REMINDER: 'Task 1 (Past Due)' was due on {past_due_str}", output)
+        self.assertNotIn("Task 2 (Future)", output) # Reminder for future task
+        self.assertNotIn("Task 3 (Already Reminded)", output) # Reminder for already reminded
+        self.assertNotIn("Task 4 (No Time)", output) # Reminder for no time task
+
+        tasks = self._read_tasks_from_temp_file()
+        expected_tasks = [
+            f"Task 1 (Past Due) || {past_due_str} || reminded",
+            f"Task 2 (Future) || {future_str}",
+            f"Task 3 (Already Reminded) || {already_reminded_past_str} || reminded",
+            "Task 4 (No Time)"
+        ]
+        # Reading from file might change order, so we check set equality or sort
+        self.assertEqual(len(tasks), len(expected_tasks))
+        self.assertCountEqual(tasks, expected_tasks) # Checks for same elements, regardless of order
+
+if __name__ == '__main__':
+    unittest.main()

--- a/todo.py
+++ b/todo.py
@@ -1,11 +1,16 @@
 import os
 import argparse
+from datetime import datetime
 TASKS_FILE = os.path.join(os.path.dirname(__file__), 'tasks.txt')
-def add_task(task_description):
+def add_task(task_description, task_time=None):
     """Add a new task to the list"""
     with open(TASKS_FILE, 'a') as f:
-        f.write(task_description + '\n')
-    print(f"Task added: {task_description}")
+        if task_time:
+            f.write(f"{task_description} || {task_time}\n")
+            print(f"Task added: {task_description} at {task_time}")
+        else:
+            f.write(task_description + '\n')
+            print(f"Task added: {task_description}")
 
 def list_tasks():
     """List all tasks from the tasks file"""
@@ -14,10 +19,71 @@ def list_tasks():
         return
     print("\n---Your To-Do List---")
     with open(TASKS_FILE, 'r') as f:
-        for i,line in enumerate(f,1): 
-            task=line.strip()
-            print(f"{i}.{task}")
+        for i, line in enumerate(f, 1):
+            line = line.strip()
+            parts = line.split(" || ")
+            task_description = parts[0]
+            if len(parts) >= 2: # Has time
+                task_time = parts[1]
+                # Check if it's marked as reminded (parts[2] would be "reminded")
+                # We don't want to show "reminded" or the raw time string if it was just a description before
+                if task_time == "reminded" and len(parts) == 2: # Should not happen with current add_task logic
+                     print(f"{i}. {task_description}")
+                elif len(parts) > 2 and parts[2] == "reminded":
+                     print(f"{i}. {task_description} (Time: {task_time}) - Reminder Sent")
+                else: # Has time, not reminded
+                     print(f"{i}. {task_description} (Time: {task_time})")
+            else: # No time
+                print(f"{i}. {task_description}")
     print("---End of List---")
+
+def check_reminders():
+    """Check for tasks that are due and print reminders."""
+    if not os.path.exists(TASKS_FILE) or os.stat(TASKS_FILE).st_size == 0:
+        print("No tasks to check for reminders.")
+        return
+
+    now = datetime.now()
+    updated_tasks = []
+    reminders_found = False
+
+    with open(TASKS_FILE, 'r') as f:
+        tasks = f.readlines()
+
+    for task_line in tasks:
+        task_line_stripped = task_line.strip()
+        parts = task_line_stripped.split(" || ")
+        
+        if len(parts) >= 2: # Task has a time
+            description = parts[0]
+            task_time_str = parts[1]
+            is_reminded = len(parts) > 2 and parts[2] == "reminded"
+
+            if not is_reminded:
+                try:
+                    task_time = datetime.strptime(task_time_str, "%Y-%m-%d %H:%M")
+                    if task_time <= now:
+                        print(f"REMINDER: '{description}' was due on {task_time_str}")
+                        updated_tasks.append(f"{description} || {task_time_str} || reminded\n")
+                        reminders_found = True
+                    else:
+                        updated_tasks.append(task_line) # Task is not due yet
+                except ValueError:
+                    # Malformed time string, keep original task line
+                    updated_tasks.append(task_line)
+            else:
+                updated_tasks.append(task_line) # Already reminded
+        else:
+            updated_tasks.append(task_line) # Task does not have a time
+
+    if reminders_found:
+        with open(TASKS_FILE, 'w') as f:
+            f.writelines(updated_tasks)
+    elif not any(" || " in task for task in tasks if "reminded" not in task.split(" || ")[-1]):
+        print("No pending tasks with due times found.")
+    else:
+        print("No tasks are currently due.")
+
 
 def delete_task(task_number):
     """Delete a task from the list"""
@@ -57,17 +123,29 @@ def main():
     # 'add' 命令
     add_parser = subparsers.add_parser("add", help="Add a new task")
     add_parser.add_argument("description", type=str, help="The description of the task")
+    add_parser.add_argument("--time", type=str, help="Optional time for the task in YYYY-MM-DD HH:MM format")
 
     # 'list' 命令
     list_parser = subparsers.add_parser("list", help="List all tasks")
+
+    # 'delete' 命令
+    delete_parser = subparsers.add_parser("delete", help="Delete a task")
+    delete_parser.add_argument("task_number", type=int, help="The number of the task to delete")
+
+    # 'remind' 命令
+    remind_parser = subparsers.add_parser("remind", help="Check for task reminders")
 
     # 解析命令行参数
     args = parser.parse_args()
 
     if args.command == "add":
-        add_task(args.description)
+        add_task(args.description, args.time)
     elif args.command == "list":
         list_tasks()
+    elif args.command == "delete":
+        delete_task(args.task_number)
+    elif args.command == "remind":
+        check_reminders()
     else:
         parser.print_help() # 如果没有指定命令或命令无效，则打印帮助信息
     


### PR DESCRIPTION
This commit introduces two major enhancements to the to-do application:

1.  **Task Deletion:**
    - You can now delete tasks using the command: `python todo.py delete <task_number>`
    - The `<task_number>` is obtained from the output of the `list` command.
    - The `delete_task` function handles invalid inputs and empty task lists gracefully.

2.  **Scheduled Tasks with Reminders:**
    - Tasks can be added with a specific due date and time using: `python todo.py add "Task description" --time "YYYY-MM-DD HH:MM"`
    - A new `remind` command (`python todo.py remind`) checks for tasks that are past their due time.
    - Due tasks are printed to the console as reminders.
    - To prevent duplicate notifications, tasks are marked as "reminded" in `tasks.txt` after the reminder is issued (e.g., `Task || TIME || reminded`).
    - The `list_tasks` command now displays the scheduled time and "Reminder Sent" status for relevant tasks.

**Supporting Changes:**
- Updated `README.md` to document the new functionalities and command-line usage.
- Added a comprehensive suite of unit tests (`test_todo.py`) using the `unittest` module to ensure the correctness of new and existing features. Tests cover various scenarios, including edge cases and use isolated temporary files for `tasks.txt`.